### PR TITLE
Added defaults to inspect

### DIFF
--- a/lib/req_chronicle/options.ex
+++ b/lib/req_chronicle/options.ex
@@ -5,7 +5,13 @@ defmodule ReqChronicle.Options do
 
   body_handler_definition = [
     type: :mfa,
-    default: {Kernel, :inspect, []},
+    default: {Kernel, :inspect, [
+      [
+        limit: :infinity,
+        pretty: true,
+        printable_limit: :infinity
+      ]
+    ]},
     doc:
       "An MFA tuple that handles request abd response bodies before persistence. The function must accept a request or response as it's first argument, and return a string."
   ]


### PR DESCRIPTION
This adds defaults to the `Kernel.inspect` function which avoids truncating information. The assumption here is that it's better to provide defaults that will *not* result in the loss of information by default. If this is not suitable then the implementer can override the options and put it into a default *unsafe* configuration.

Closes https://github.com/supersimplesuper/code/issues/2684