### PR TITLE
Add custom persistence for bulk inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,36 @@ YourApp.ApiClient.make_request("https://api.example.com/data")
 
 This will make the request using Req, and ReqChronicle will log and persist the request and response based on your configuration.
 
+## Changing default persistence
+
+ReqChronicle will use the provided schema to store the request and response data synchronously if persistence is enabled. As a consequence, the database can become a bottleneck if a large number of requests are made in a short period of time.
+
+ReqChronicle provides a `:persistence_callback` option that is called instead of the default persistence logic. This persistence callback options should be a tuple with the module and function name to call, such as `{YourApp.Chronicle, :do_persist}`.
+
+```elixir
+  use ReqChronicle,
+    persistence: [
+      requests: [
+        enabled: true,
+        schema: YourApp.ChronicleRequest
+      ],
+      responses: [
+        enabled: true,
+        schema: YourApp.ChronicleResponse
+      ],
+      repo: YourApp.Repo,
+      persistence_callback: {YourApp.Chronicle, :do_persist}
+    ],
+```
+
+This will call the function with the following arguments:
+
+- The repo module (e.g. `YourApp.Repo`).
+- The schema (e.g. `YourApp.ChronicleRequest` or `YourApp.ChronicleResponse`).
+- The parameters associated with the schema.
+
+This function should return the ID of the newly created record. However, if the persistence is asynchronous, it is strongly advised that the ID be generated beforehand.
+
 # Help
 
 You can adjust the configuration options to enable/disable logging or persistence, change log levels, or provide custom body handlers as needed.

--- a/lib/req_chronicle/options.ex
+++ b/lib/req_chronicle/options.ex
@@ -5,15 +5,17 @@ defmodule ReqChronicle.Options do
 
   body_handler_definition = [
     type: :mfa,
-    default: {Kernel, :inspect, [
-      [
-        limit: :infinity,
-        pretty: true,
-        printable_limit: :infinity
-      ]
-    ]},
+    default:
+      {Kernel, :inspect,
+       [
+         [
+           limit: :infinity,
+           pretty: true,
+           printable_limit: :infinity
+         ]
+       ]},
     doc:
-      "An MFA tuple that handles request abd response bodies before persistence. The function must accept a request or response as it's first argument, and return a string."
+      "An MFA tuple that handles request and response bodies before persistence. The function must accept a request or response as it's first argument, and return a string."
   ]
 
   schema_definition = [
@@ -73,6 +75,14 @@ defmodule ReqChronicle.Options do
       type: :atom,
       required: false,
       doc: "The Repo module to use for storing requests and responses."
+    ],
+    persistence_callback: [
+      type: :mod_arg,
+      required: false,
+      doc: ~s(
+        An module argument that is called instead of default persistence. Its arguments will be the configured repo,
+        schema, record, andd parameters and should return the inserted record with an ID.
+      )
     ]
   ]
 


### PR DESCRIPTION
This adds an escape hatch to allow users to define their own methods to persist request and responses. This is the stepping stone to allow the use of Broadway to save these entries in bulk.